### PR TITLE
Add -c flag for --slurp

### DIFF
--- a/src/slurp.rs
+++ b/src/slurp.rs
@@ -182,6 +182,8 @@ impl SlurpGeom {
         } else {
             // sane slurp defaults
             slurp_cmd
+                .arg("-c") // selection border
+                .arg("#000000") // opaque black
                 .arg("-b") // background
                 .arg("#000000C0") // 0.75 opaque black
                 .arg("-B") // boxes


### PR DESCRIPTION
Allows users to configure the border colors for slurp as seen here (sorry for the white):

![2024-09-09T23:06:25-07:00](https://github.com/user-attachments/assets/ca42eeef-1654-4528-ad16-077884654285)

https://github.com/user-attachments/assets/70e8744b-704a-4d01-bbaf-4806d9404022